### PR TITLE
feat: replace tab character with space in console output

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,18 +1,18 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:49:49Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
 codecov:
-require_ci_to_pass: false
+  require_ci_to_pass: false
 
 coverage:
-status:
-  project:
-    default:
-      target: 50%
-      threshold: 0.5%
-      base: auto
-      if_ci_failed: success
-  patch: off
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 0.5%
+        base: auto
+        if_ci_failed: success
+    patch: off
 
 comment: false

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:49:49Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
 policies:
 - type: commit
@@ -19,7 +19,7 @@ policies:
       required: true
     conventional:
       types: ["chore","docs","perf","refactor","style","test","release"]
-      scopes: ["*"]
+      scopes: [".*"]
 - type: license
   spec:
     skipPaths:
@@ -28,6 +28,7 @@ policies:
       - .go
     excludeSuffixes:
       - .pb.go
+      - .pb.gw.go
     header: |
       // This Source Code Form is subject to the terms of the Mozilla Public
       // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:49:49Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
 kind: pipeline
 type: kubernetes
@@ -121,6 +121,56 @@ steps:
     path: /root/.ssh
   depends_on:
   - base
+
+- name: release-notes
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make release-notes
+  volumes:
+  - name: outer-docker-socket
+    path: /var/outer-run
+  - name: docker-socket
+    path: /var/run
+  - name: buildx
+    path: /root/.docker/buildx
+  - name: ssh
+    path: /root/.ssh
+  when:
+    event:
+    - tag
+  depends_on:
+  - unit-tests
+  - coverage
+  - lint
+
+- name: release
+  pull: always
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    checksum:
+    - sha256
+    - sha512
+    draft: true
+    files:
+    - _out/*
+    note: _out/RELEASE_NOTES.md
+  volumes:
+  - name: outer-docker-socket
+    path: /var/outer-run
+  - name: docker-socket
+    path: /var/run
+  - name: buildx
+    path: /root/.docker/buildx
+  - name: ssh
+    path: /root/.ssh
+  when:
+    event:
+    - tag
+  depends_on:
+  - release-notes
 
 services:
 - name: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:58:40Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -16,7 +16,7 @@ RUN npm i sentences-per-line@0.2.1
 WORKDIR /src
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
-RUN markdownlint --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
+RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
 
 # base toolchain image
 FROM ${TOOLCHAIN} AS toolchain
@@ -54,6 +54,7 @@ RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
 # runs gofumpt
 FROM base AS lint-gofumpt
 RUN find . -name '*.pb.go' | xargs -r rm
+RUN find . -name '*.pb.gw.go' | xargs -r rm
 RUN FILES="$(gofumports -l -local github.com/talos-systems/go-kmsg .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local github.com/talos-systems/go-kmsg .':\n${FILES}"; exit 1)
 
 # runs golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:58:40Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
 # common variables
 
@@ -12,9 +12,10 @@ REGISTRY ?= ghcr.io
 USERNAME ?= talos-systems
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
-GO_VERSION ?= 1.14
+GO_VERSION ?= 1.16
 PROTOBUF_GO_VERSION ?= 1.25.0
 GRPC_GO_VERSION ?= 1.1.0
+GRPC_GATEWAY_VERSION ?= 2.4.0
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
 
@@ -37,6 +38,7 @@ COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
 COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION=$(PROTOBUF_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
+COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
 TOOLCHAIN ?= docker.io/golang:1.16-alpine
 
@@ -130,4 +132,9 @@ rekres:
 help:  ## This help menu.
 	@echo "$$HELP_MENU_HEADER"
 	@grep -E '^[a-zA-Z%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: release-notes
+release-notes:
+	mkdir -p $(ARTIFACTS)
+	@ARTIFACTS=$(ARTIFACTS) ./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,16 +2,23 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-04T14:49:49Z by kres 1844a99-dirty.
+# Generated on 2021-06-23T20:37:16Z by kres latest.
 
+
+#!/bin/bash
 
 set -e
 
+RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+
+function release-tool {
+  docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null
+  docker run --rm -w /src -v "${PWD}":/src:ro "${RELEASE_TOOL_IMAGE}" -l -d -n -t "${1}" ./hack/release.toml
+}
+
 function changelog {
   if [ "$#" -eq 1 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.0.."
-  elif [ "$#" -eq 0 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml
+    (release-tool ${1}; echo; cat CHANGELOG.md) > CHANGELOG.md- && mv CHANGELOG.md- CHANGELOG.md
   else
     echo 1>&2 "Usage: $0 changelog [tag]"
     exit 1
@@ -19,7 +26,7 @@ function changelog {
 }
 
 function release-notes {
-  git-chglog --output ${1} -c ./hack/git-chglog/config.yaml "${2}"
+  release-tool "${2}" > "${1}"
 }
 
 function cherry-pick {
@@ -51,9 +58,10 @@ then
 else
   cat <<EOF
 Usage:
-  commit:       Create the official release commit message.
-  cherry-pick:  Cherry-pick a commit into a release branch.
-  changelog:    Update the specified CHANGELOG.
+  commit:        Create the official release commit message.
+  cherry-pick:   Cherry-pick a commit into a release branch.
+  changelog:     Update the specified CHANGELOG.
+  release-notes: Create release notes for GitHub release.
 EOF
 
   exit 1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -1,0 +1,16 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2021-06-23T20:37:16Z by kres latest.
+
+
+# commit to be tagged for the new release
+commit = "HEAD"
+
+project_name = "go-kmsg"
+github_repo = "talos-systems/go-kmsg"
+match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
+
+# previous = -
+# pre_release = true
+
+# [notes]

--- a/writer.go
+++ b/writer.go
@@ -33,6 +33,10 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 			line = append(line[:MaxLineLength-4], []byte("...\n")...)
 		}
 
+		// replace tab characters from multierror library error messages with spaces,
+		// as tabs are not visible in the console
+		line = bytes.ReplaceAll(line, []byte{'\t'}, []byte{' '})
+
 		var nn int
 		nn, err = w.KmsgWriter.Write(line)
 
@@ -43,11 +47,11 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		}
 
 		if err != nil {
-			return
+			return n, err
 		}
 
 		p = p[i+1:]
 	}
 
-	return
+	return n, err
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -43,8 +43,8 @@ func TestWriter(t *testing.T) {
 	assert.Equal(t, kmsg.MaxLineLength, n)
 	assert.NoError(t, err)
 
-	n, err = kmsgW.Write(append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength), '\n', 'a', 'b', '\n'))
-	assert.Equal(t, kmsg.MaxLineLength+4, n)
+	n, err = kmsgW.Write(append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength), '\n', 'a', '\t', 'b', '\n'))
+	assert.Equal(t, kmsg.MaxLineLength+5, n)
 	assert.NoError(t, err)
 
 	assert.Len(t, fakeW.lines, 7)
@@ -54,5 +54,5 @@ func TestWriter(t *testing.T) {
 	assert.Equal(t, fakeW.lines[3], []byte("bar\n"))
 	assert.Equal(t, fakeW.lines[4], append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength-1), '\n'))
 	assert.Equal(t, fakeW.lines[5], append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength-4), '.', '.', '.', '\n'))
-	assert.Equal(t, fakeW.lines[6], []byte("ab\n"))
+	assert.Equal(t, fakeW.lines[6], []byte("a b\n"))
 }


### PR DESCRIPTION
Tabs are not rendered properly in console (as multiple spaces), but they
are generated by say `go-multierror` in error description.

Also rekres to update dependencies.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>